### PR TITLE
add external repo to ref

### DIFF
--- a/yolox-ros.repos
+++ b/yolox-ros.repos
@@ -1,0 +1,6 @@
+repositories:
+  h6x_detection_interfaces:
+    type: git
+    url: https://github.com/HarvestX/h6x_detection_interfaces.git
+    version: main
+


### PR DESCRIPTION
以下のコマンドを叩くと、外部のRepositoryが取り込まれるはずです。
```bash
cd ~/ros2_ws/src
vcs import < YOLOX-ROS/yolox-ros.repos
```
