### PR TITLE
0222-still-bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ YOLOX_outputs/
 *.onnx
 *.trt
 *.engine
+.vscode

--- a/yolox_ros_cpp/docker/tensorrt/dockerfile
+++ b/yolox_ros_cpp/docker/tensorrt/dockerfile
@@ -50,6 +50,7 @@ CMD ["bash"]
 # docker build . -t yolox_ros_tensorrt
 # docker run --rm -it --network host --runtime nvidia -v /home/ubuntu-i9rtx/Documents/github/yolox_ros_galactic_dir/src/:/root/ros2_ws/src -v /tmp/.X11-unix:/tmp/.X11-unix -w /root/ros2_ws -e DISPLAY=$DISPLAY --device /dev/video0:/dev/video0 yolox_ros_tensorrt /bin/bash
 
+# source /opt/ros/galactic/setup.bash
 # colcon build --symlink-install --cmake-args -DYOLOX_USE_TENSORRT=ON -DYOLOX_USE_OPENVINO=OFF
 # cd ~/ && git clone https://github.com/NVIDIA-AI-IOT/torch2trt && cd torch2trt && python3 setup.py install
 

--- a/yolox_ros_cpp/docker/tensorrt/dockerfile
+++ b/yolox_ros_cpp/docker/tensorrt/dockerfile
@@ -48,7 +48,7 @@ RUN git clone https://github.com/Megvii-BaseDetection/YOLOX -b $YOLOX_VERSION &&
 CMD ["bash"]
 
 # docker build . -t yolox_ros_tensorrt
-# docker run --rm -it --network host --runtime nvidia -v /home/ubuntu-i9rtx/Documents/github/YOLOX-ROS:/root/ros2_ws/src/YOLOX-ROS -v /tmp/.X11-unix:/tmp/.X11-unix -w /root/ros2_ws -e DISPLAY=$DISPLAY --device /dev/video0:/dev/video0 yolox_ros_tensorrt /bin/bash
+# docker run --rm -it --network host --runtime nvidia -v /home/ubuntu-i9rtx/Documents/github/yolox_ros_galactic_dir/src/:/root/ros2_ws/src -v /tmp/.X11-unix:/tmp/.X11-unix -w /root/ros2_ws -e DISPLAY=$DISPLAY --device /dev/video0:/dev/video0 yolox_ros_tensorrt /bin/bash
 
 # colcon build --symlink-install --cmake-args -DYOLOX_USE_TENSORRT=ON -DYOLOX_USE_OPENVINO=OFF
 # cd ~/ && git clone https://github.com/NVIDIA-AI-IOT/torch2trt && cd torch2trt && python3 setup.py install

--- a/yolox_ros_cpp/yolox_cpp/CMakeLists.txt
+++ b/yolox_ros_cpp/yolox_cpp/CMakeLists.txt
@@ -60,6 +60,9 @@ configure_file(
   "${PROJECT_SOURCE_DIR}/include/yolox_cpp/config.h"
 )
 
+# Jetson
+# include_directories(/usr/local/cuda-10.2/targets/aarch64-linux/include)
+# link_directories(/usr/local/cuda-10.2/targets/aarch64-linux/lib)
 
 add_library(yolox_cpp SHARED
   ${SRC}

--- a/yolox_ros_cpp/yolox_cpp/include/yolox_cpp/yolox_tensorrt.hpp
+++ b/yolox_ros_cpp/yolox_cpp/include/yolox_cpp/yolox_tensorrt.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <fstream>
 #include <opencv2/opencv.hpp>
 
 #include "cuda_runtime_api.h"

--- a/yolox_ros_cpp/yolox_cpp/src/yolox_tensorrt.cpp
+++ b/yolox_ros_cpp/yolox_cpp/src/yolox_tensorrt.cpp
@@ -290,6 +290,7 @@ namespace yolox_cpp{
         nms_sorted_bboxes(proposals, picked, this->nms_thresh_);
 
         int count = picked.size();
+        std::cout << "num of boxes: " << count << std::endl;
 
         objects.resize(count);
         for (int i = 0; i < count; i++)

--- a/yolox_ros_cpp/yolox_cpp/src/yolox_tensorrt.cpp
+++ b/yolox_ros_cpp/yolox_cpp/src/yolox_tensorrt.cpp
@@ -269,7 +269,7 @@ namespace yolox_cpp{
                 for (size_t w = 0; w < img_w; w++) 
                 {
                     blob[c * img_w * img_h + h * img_w + w] =
-                        (((float)img.at<cv::Vec3b>(h, w)[c]) / 255.0f - this->mean_[c]) / this->std_[c];
+                        (float)img.at<cv::Vec3b>(h, w)[c]; // / 255.0f - this->mean_[c]) / this->std_[c];
                 }
             }
         }
@@ -290,7 +290,7 @@ namespace yolox_cpp{
         nms_sorted_bboxes(proposals, picked, this->nms_thresh_);
 
         int count = picked.size();
-        std::cout << "num of boxes: " << count << std::endl;
+        // std::cout << "num of boxes: " << count << std::endl;
 
         objects.resize(count);
         for (int i = 0; i < count; i++)

--- a/yolox_ros_cpp/yolox_ros_cpp/CMakeLists.txt
+++ b/yolox_ros_cpp/yolox_ros_cpp/CMakeLists.txt
@@ -24,7 +24,8 @@ find_package(sensor_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(bboxes_ex_msgs REQUIRED)
+find_package(bboxes_ex_msgs QUIET)
+find_package(yolo_msgs REQUIRED)
 find_package(yolox_cpp)
 
 if(NOT yolox_cpp_FOUND)
@@ -57,6 +58,7 @@ ament_target_dependencies(yolox_ros_cpp
   sensor_msgs
   OpenCV
   yolox_cpp
+  yolo_msgs
   bboxes_ex_msgs
   )
 
@@ -65,6 +67,77 @@ install(TARGETS yolox_ros_cpp
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib
 )
+
+# srv ================================================================
+add_library(yolox_ros_cpp_srv SHARED
+  src/yolox_ros_cpp_srv.cpp
+)
+rclcpp_components_register_nodes(yolox_ros_cpp_srv
+ "yolox_ros_cpp_srv::YoloXSrv")
+target_compile_definitions(yolox_ros_cpp_srv
+  PRIVATE "MY_LIBRARY_BUILDING_LIBRARY"
+)
+target_compile_options(yolox_ros_cpp_srv PUBLIC -Wall)
+
+target_include_directories(yolox_ros_cpp_srv PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(yolox_ros_cpp_srv
+  rclcpp
+  rclcpp_components
+  cv_bridge
+  image_transport
+  builtin_interfaces
+  std_msgs
+  sensor_msgs
+  OpenCV
+  yolox_cpp
+  yolo_msgs
+  )
+
+
+install(TARGETS yolox_ros_cpp_srv
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib
+)
+
+# using srv ================================================================
+add_library(using_service_v4l2camera SHARED
+  src/using_service_v4l2camera.cpp
+)
+rclcpp_components_register_nodes(using_service_v4l2camera
+ "using_service_v4l2camera::using_service")
+target_compile_definitions(using_service_v4l2camera
+  PRIVATE "MY_LIBRARY_BUILDING_LIBRARY"
+)
+target_compile_options(using_service_v4l2camera PUBLIC -Wall)
+
+target_include_directories(using_service_v4l2camera PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(using_service_v4l2camera
+  rclcpp
+  rclcpp_components
+  cv_bridge
+  image_transport
+  builtin_interfaces
+  std_msgs
+  sensor_msgs
+  OpenCV
+  yolo_msgs
+  )
+
+
+install(TARGETS using_service_v4l2camera
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib
+)
+
+# ================================================================
 
 install(DIRECTORY
   launch

--- a/yolox_ros_cpp/yolox_ros_cpp/include/yolox_ros_cpp/using_service_v4l2camera.hpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/include/yolox_ros_cpp/using_service_v4l2camera.hpp
@@ -7,6 +7,7 @@
 
 #include "yolo_msgs/srv/detect_object.hpp"
 #include "yolo_msgs/msg/bounding_box.hpp"
+#include "yolo_msgs/msg/bounding_boxes.hpp"
 
 #include <chrono>
 
@@ -19,6 +20,7 @@ namespace using_service_v4l2camera{
             rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future_yolox;
 
             rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_image;
+            rclcpp::Publisher<yolo_msgs::msg::BoundingBoxes>::SharedPtr pub_boundingboxes;
             yolo_msgs::srv::DetectObject::Request::SharedPtr request;
 
             sensor_msgs::msg::Image::SharedPtr image_msg;

--- a/yolox_ros_cpp/yolox_ros_cpp/include/yolox_ros_cpp/using_service_v4l2camera.hpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/include/yolox_ros_cpp/using_service_v4l2camera.hpp
@@ -1,0 +1,41 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+
+#include "sensor_msgs/msg/image.hpp"
+#include "cv_bridge/cv_bridge.h"
+#include "opencv2/opencv.hpp"
+
+#include "yolo_msgs/srv/detect_object.hpp"
+#include "yolo_msgs/msg/bounding_box.hpp"
+
+#include <chrono>
+
+namespace using_service_v4l2camera{
+
+    class using_service:public rclcpp::Node
+    {   
+        private:
+            rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedPtr client_yolox;
+            rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future_yolox;
+
+            rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_image;
+            yolo_msgs::srv::DetectObject::Request::SharedPtr request;
+
+            sensor_msgs::msg::Image::SharedPtr image_msg;
+            
+
+            // frame cache
+            cv::Mat frame;
+
+            void yolox_callback();
+
+            void callback_response(rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future);
+
+            // Subscription
+            void callback_image(const sensor_msgs::msg::Image::SharedPtr msg);
+
+        public:
+            using_service(const rclcpp::NodeOptions& options);
+    };
+    
+}

--- a/yolox_ros_cpp/yolox_ros_cpp/include/yolox_ros_cpp/yolox_ros_cpp_srv.hpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/include/yolox_ros_cpp/yolox_ros_cpp_srv.hpp
@@ -1,0 +1,66 @@
+#ifndef _YOLOX_ROS_CPP_YOLOX_ROS_CPP_HPP
+#define _YOLOX_ROS_CPP_YOLOX_ROS_CPP_HPP
+#include <math.h>
+#include <chrono>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+// #include <ament_index_cpp/get_package_share_directory.hpp>
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.hpp>
+
+// #include "bboxes_ex_msgs/msg/bounding_box.hpp"
+// #include "bboxes_ex_msgs/msg/bounding_boxes.hpp"
+
+#include "yolo_msgs/srv/detect_object.hpp"
+#include "yolo_msgs/msg/bounding_box.hpp"
+// #include "yolo_msgs/msg/bounding_boxes.hpp"
+
+
+#include "yolox_cpp/yolox.hpp"
+#include "yolox_cpp/utils.hpp"
+
+namespace yolox_ros_cpp_srv{
+
+    class YoloXSrv : public rclcpp::Node
+    {
+    public:
+        YoloXSrv(const rclcpp::NodeOptions& options);
+        YoloXSrv(const std::string &node_name, const rclcpp::NodeOptions& options);
+
+    private:
+        void initializeParameter();
+        std::unique_ptr<yolox_cpp::AbsYoloX> yolox_;
+        std::string model_path_;
+        std::string model_type_;
+        std::string device_;
+        float conf_th_;
+        float nms_th_;
+        int image_width_;
+        int image_height_;
+
+        std::string src_image_topic_name_;
+        std::string publish_image_topic_name_;
+        std::string publish_boundingbox_topic_name_;
+
+        image_transport::Subscriber sub_image_;
+        // void colorImageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& ptr);
+        void colorImageSrvCallback( const std::shared_ptr<rmw_request_id_t> request_header,
+                                    const std::shared_ptr<yolo_msgs::srv::DetectObject::Request> req,
+                                    std::shared_ptr<yolo_msgs::srv::DetectObject::Response> res
+                                    );
+
+        // rclcpp::Publisher<bboxes_ex_msgs::msg::BoundingBoxes>::SharedPtr pub_bboxes_;
+        // image_transport::Publisher pub_image_;
+
+        rclcpp::Service<yolo_msgs::srv::DetectObject>::SharedPtr srv_detect_object_;
+
+        // yolo_msgs::msg::BoundingBoxes objects_to_bboxes(cv::Mat frame, std::vector<yolox_cpp::Object> objects, std_msgs::msg::Header header);
+        std::vector<yolo_msgs::msg::BoundingBox> objects_to_bboxes(cv::Mat frame, std::vector<yolox_cpp::Object> objects, std_msgs::msg::Header header);
+
+        std::string WINDOW_NAME_ = "YOLOX";
+        bool imshow_ = true;
+    };
+}
+#endif

--- a/yolox_ros_cpp/yolox_ros_cpp/launch/yolox_service_v4l2camera.launch.py
+++ b/yolox_ros_cpp/yolox_ros_cpp/launch/yolox_service_v4l2camera.launch.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import launch
+import launch_ros.actions
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+def generate_launch_description():
+    yolox_ros_share_dir = get_package_share_directory('yolox_ros_cpp')
+    yolox_param_yaml = os.path.join(yolox_ros_share_dir, "param", "nano_torch2trt.yaml")
+
+    container = ComposableNodeContainer(
+                name='yolox_container',
+                namespace='',
+                package='rclcpp_components',
+                executable='component_container',
+                composable_node_descriptions=[
+
+                    # v4l2_camera component
+                    ComposableNode(
+                        package='v4l2_camera',
+                        plugin='v4l2_camera::V4L2Camera',
+                        name='v4l2_camera',
+                        parameters=[{
+                            "image_size": [640,480]
+                        }]),
+
+                    # image subscriber component
+                    ComposableNode(
+                        package='yolox_ros_cpp',
+                        plugin='using_service_v4l2camera::using_service',
+                        name='sub_v4l2camera',
+                        ),
+
+                    # YOLOX component
+                    ComposableNode(
+                        package='yolox_ros_cpp',
+                        plugin='yolox_ros_cpp_srv::YoloXSrv',
+                        name='yolox_ros_cpp_srv',
+                        parameters=[yolox_param_yaml],
+                        )
+                ],
+                output='screen',
+        )
+
+    rqt_graph = launch_ros.actions.Node(
+        package="rqt_graph", executable="rqt_graph",
+    )
+
+    return launch.LaunchDescription([
+        container,
+        # rqt_graph,
+    ])

--- a/yolox_ros_cpp/yolox_ros_cpp/launch/yolox_service_v4l2camera.launch.py
+++ b/yolox_ros_cpp/yolox_ros_cpp/launch/yolox_service_v4l2camera.launch.py
@@ -8,7 +8,7 @@ from launch_ros.descriptions import ComposableNode
 
 def generate_launch_description():
     yolox_ros_share_dir = get_package_share_directory('yolox_ros_cpp')
-    yolox_param_yaml = os.path.join(yolox_ros_share_dir, "param", "nano_torch2trt.yaml")
+    yolox_param_yaml = os.path.join(yolox_ros_share_dir, "param", "tiny_trtexec.yaml")
 
     container = ComposableNodeContainer(
                 name='yolox_container',

--- a/yolox_ros_cpp/yolox_ros_cpp/package.xml
+++ b/yolox_ros_cpp/yolox_ros_cpp/package.xml
@@ -17,6 +17,7 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>bboxes_ex_msgs</depend>
+  <depend>yolo_msgs</depend>
   <depend>yolox_cpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/yolox_ros_cpp/yolox_ros_cpp/src/using_service_v4l2camera.cpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/src/using_service_v4l2camera.cpp
@@ -44,11 +44,18 @@ namespace using_service_v4l2camera
         }
 
         // print all
-        for (auto &bbox : response->bounding_boxes)
-        {
-            RCLCPP_INFO(this->get_logger(), "xmin: %d, ymin: %d, xmax: %d, ymax: %d, class_id: %s, confidence: %f",
-                        bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax, bbox.class_id.c_str(), bbox.confidence);
-        }
+        // for (auto &bbox : response->bounding_boxes)
+        // {
+        //     RCLCPP_INFO(this->get_logger(), "xmin: %d, ymin: %d, xmax: %d, ymax: %d, class_id: %s, confidence: %f",
+        //                 bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax, bbox.class_id.c_str(), bbox.confidence);
+        // 
+        // }
+
+        // Publish bboxes
+        yolo_msgs::msg::BoundingBoxes boundingboxes_msg;
+        boundingboxes_msg.bounding_boxes = boundingboxes;
+        pub_boundingboxes->publish(boundingboxes_msg);
+
         // draw boundingboxes
         for (auto &bbox : boundingboxes)
         {
@@ -81,6 +88,7 @@ namespace using_service_v4l2camera
     {
         client_yolox = this->create_client<yolo_msgs::srv::DetectObject>("detect_object");
         sub_image = this->create_subscription<sensor_msgs::msg::Image>("image_raw", 10, std::bind(&using_service::callback_image, this, _1));
+        pub_boundingboxes = this->create_publisher<yolo_msgs::msg::BoundingBoxes>("boundingboxes", 10);
     }
 }
 

--- a/yolox_ros_cpp/yolox_ros_cpp/src/using_service_v4l2camera.cpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/src/using_service_v4l2camera.cpp
@@ -1,0 +1,112 @@
+#include "yolox_ros_cpp/using_service_v4l2camera.hpp"
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
+namespace using_service_v4l2camera
+{
+
+    void using_service::yolox_callback()
+    {
+        RCLCPP_INFO(this->get_logger(), "yolox_callback");
+        while (!client_yolox->wait_for_service(1s))
+        {
+            if (!rclcpp::ok())
+            {
+                RCLCPP_INFO(this->get_logger(), "Client interrupted while waiting for service");
+                // exit(-1);
+                return ;
+            }
+            RCLCPP_INFO(this->get_logger(), "waiting for service...");
+        }
+        
+
+        request = std::make_shared<yolo_msgs::srv::DetectObject::Request>();
+        request->image = *image_msg;
+        // future_yolox = client_yolox->async_send_request(request);
+
+        
+
+        future_yolox = client_yolox->async_send_request(request, std::bind(&using_service::callback_response,this,_1));
+
+        // future_yolox = client_yolox->async_send_request(request);
+        
+    }
+
+    // void callback_response(rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future){
+    //     auto response = future.get();
+    // }
+    void using_service::callback_response(rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future) {
+        auto response = future.get();
+        RCLCPP_INFO(this->get_logger(), "callback_response");
+
+        std::vector<yolo_msgs::msg::BoundingBox> boundingboxes;
+        for (auto &box : response->bounding_boxes)
+        {
+            yolo_msgs::msg::BoundingBox boundingbox;
+            boundingbox.xmin = box.xmin;
+            boundingbox.ymin = box.ymin;
+            boundingbox.xmax = box.xmax;
+            boundingbox.ymax = box.ymax;
+            boundingbox.class_id = box.class_id;
+            boundingbox.confidence = box.confidence;
+            boundingboxes.push_back(boundingbox);
+        }
+
+        // print all
+        for (auto &bbox : response->bounding_boxes)
+        {
+            RCLCPP_INFO(this->get_logger(), "xmin: %d, ymin: %d, xmax: %d, ymax: %d, class_id: %s, confidence: %f",
+                        bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax, bbox.class_id.c_str(), bbox.confidence);
+        }
+        // draw boundingboxes
+        for (auto &bbox : boundingboxes)
+        {
+            cv::rectangle(frame, cv::Point(bbox.xmin, bbox.ymin), cv::Point(bbox.xmax, bbox.ymax), cv::Scalar(0, 255, 0), 2);
+        }
+        cv::imshow("frame", frame);
+        cv::waitKey(1);
+    }
+
+    // Subscription
+    void using_service::callback_image(const sensor_msgs::msg::Image::SharedPtr msg)
+    {
+        cv_bridge::CvImagePtr cv_ptr;
+        try
+        {
+            cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+        }
+        catch (cv_bridge::Exception& e)
+        {
+            RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());
+            return;
+        }
+
+        frame = cv_ptr->image;
+        image_msg = msg;
+        // imwrite to file
+        // cv::imwrite("/root/ros2_ws/src/image.jpg", frame);
+        yolox_callback();
+    }
+
+    using_service::using_service(const rclcpp::NodeOptions& options): Node("using_service", options)
+    {
+        client_yolox = this->create_client<yolo_msgs::srv::DetectObject>("detect_object");
+        sub_image = this->create_subscription<sensor_msgs::msg::Image>("image_raw", 10, std::bind(&using_service::callback_image, this, _1));
+    }
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(using_service_v4l2camera::using_service)
+
+
+
+// int main(int argc, char** argv)
+// {
+//     rclcpp::init(argc, argv);
+//     rclcpp::NodeOptions options;
+//     auto node = std::make_shared<using_service>("using_service",options);
+
+//     rclcpp::spin(node);
+//     rclcpp::shutdown();
+//     return 0;
+// }

--- a/yolox_ros_cpp/yolox_ros_cpp/src/using_service_v4l2camera.cpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/src/using_service_v4l2camera.cpp
@@ -14,7 +14,6 @@ namespace using_service_v4l2camera
             if (!rclcpp::ok())
             {
                 RCLCPP_INFO(this->get_logger(), "Client interrupted while waiting for service");
-                // exit(-1);
                 return ;
             }
             RCLCPP_INFO(this->get_logger(), "waiting for service...");
@@ -23,19 +22,10 @@ namespace using_service_v4l2camera
 
         request = std::make_shared<yolo_msgs::srv::DetectObject::Request>();
         request->image = *image_msg;
-        // future_yolox = client_yolox->async_send_request(request);
-
-        
 
         future_yolox = client_yolox->async_send_request(request, std::bind(&using_service::callback_response,this,_1));
-
-        // future_yolox = client_yolox->async_send_request(request);
-        
     }
 
-    // void callback_response(rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future){
-    //     auto response = future.get();
-    // }
     void using_service::callback_response(rclcpp::Client<yolo_msgs::srv::DetectObject>::SharedFuture future) {
         auto response = future.get();
         RCLCPP_INFO(this->get_logger(), "callback_response");
@@ -84,8 +74,6 @@ namespace using_service_v4l2camera
 
         frame = cv_ptr->image;
         image_msg = msg;
-        // imwrite to file
-        // cv::imwrite("/root/ros2_ws/src/image.jpg", frame);
         yolox_callback();
     }
 

--- a/yolox_ros_cpp/yolox_ros_cpp/src/yolox_ros_cpp_srv.cpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/src/yolox_ros_cpp_srv.cpp
@@ -141,11 +141,7 @@ namespace yolox_ros_cpp_srv{
 
         // fps
         auto now = std::chrono::system_clock::now();
-        RCLCPP_INFO(this->get_logger(), "step?: %d", step++);
         auto objects = this->yolox_->inference(frame);
-        RCLCPP_INFO(this->get_logger(), "step!: %d", step++);
-
-        RCLCPP_INFO(this->get_logger(), "step: %d", step++);
 
         yolox_cpp::utils::draw_objects(frame, objects);
         std::vector<yolo_msgs::msg::BoundingBox> boxes = objects_to_bboxes(frame, objects, img->header);

--- a/yolox_ros_cpp/yolox_ros_cpp/src/yolox_ros_cpp_srv.cpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/src/yolox_ros_cpp_srv.cpp
@@ -12,13 +12,13 @@ namespace yolox_ros_cpp_srv{
         RCLCPP_INFO(this->get_logger(), "initialize");
         this->initializeParameter();
 
-        if(this->imshow_){
-            char window_name[50];
-            sprintf(window_name, "%s %s %s", this->WINDOW_NAME_.c_str(), "_", this->get_name());
-            this->WINDOW_NAME_ = window_name;            
+        // if(this->imshow_){
+        //     char window_name[50];
+        //     sprintf(window_name, "%s %s %s", this->WINDOW_NAME_.c_str(), "_", this->get_name());
+        //     this->WINDOW_NAME_ = window_name;            
 
-            cv::namedWindow(this->WINDOW_NAME_, cv::WINDOW_AUTOSIZE);
-        }
+        //     cv::namedWindow(this->WINDOW_NAME_, cv::WINDOW_AUTOSIZE);
+        // }
         
         if(this->model_type_ == "tensorrt"){
             #ifdef ENABLE_TENSORRT
@@ -137,13 +137,13 @@ namespace yolox_ros_cpp_srv{
         (void)request_header;
 
         auto img = cv_bridge::toCvCopy(req->image, "bgr8");
-        cv::Mat frame = img->image;
-
-        RCLCPP_INFO(this->get_logger(), "step: %d", step++);
+        cv::Mat frame = img->image.clone();
 
         // fps
         auto now = std::chrono::system_clock::now();
+        RCLCPP_INFO(this->get_logger(), "step?: %d", step++);
         auto objects = this->yolox_->inference(frame);
+        RCLCPP_INFO(this->get_logger(), "step!: %d", step++);
 
         RCLCPP_INFO(this->get_logger(), "step: %d", step++);
 

--- a/yolox_ros_cpp/yolox_ros_cpp/src/yolox_ros_cpp_srv.cpp
+++ b/yolox_ros_cpp/yolox_ros_cpp/src/yolox_ros_cpp_srv.cpp
@@ -1,0 +1,184 @@
+#include "yolox_ros_cpp/yolox_ros_cpp_srv.hpp"
+
+namespace yolox_ros_cpp_srv{
+
+    YoloXSrv::YoloXSrv(const rclcpp::NodeOptions& options)
+    : YoloXSrv::YoloXSrv("", options)
+    {}
+
+    YoloXSrv::YoloXSrv(const std::string &node_name, const rclcpp::NodeOptions& options)
+    : rclcpp::Node("yolox_ros_cpp_srv", node_name, options){
+        
+        RCLCPP_INFO(this->get_logger(), "initialize");
+        this->initializeParameter();
+
+        if(this->imshow_){
+            char window_name[50];
+            sprintf(window_name, "%s %s %s", this->WINDOW_NAME_.c_str(), "_", this->get_name());
+            this->WINDOW_NAME_ = window_name;            
+
+            cv::namedWindow(this->WINDOW_NAME_, cv::WINDOW_AUTOSIZE);
+        }
+        
+        if(this->model_type_ == "tensorrt"){
+            #ifdef ENABLE_TENSORRT
+                RCLCPP_INFO(this->get_logger(), "Model Type is TensorRT");
+                this->yolox_ = std::make_unique<yolox_cpp::YoloXTensorRT>(this->model_path_, std::stoi(this->device_),
+                                                                          this->nms_th_, this->conf_th_, 
+                                                                          this->image_width_, this->image_height_);
+            #else
+                RCLCPP_ERROR(this->get_logger(), "yolox_cpp is not built with TensorRT");
+                rclcpp::shutdown();
+            #endif
+        }else if(this->model_type_ == "openvino"){
+            #ifdef ENABLE_OPENVINO
+                RCLCPP_INFO(this->get_logger(), "Model Type is OpenVINO");
+                this->yolox_ = std::make_unique<yolox_cpp::YoloXOpenVINO>(this->model_path_, this->device_,
+                                                                          this->nms_th_, this->conf_th_,
+                                                                          this->image_width_, this->image_height_);
+            #else
+                RCLCPP_ERROR(this->get_logger(), "yolox_cpp is not built with OpenVINO");
+                rclcpp::shutdown();
+            #endif
+        }
+
+        // this->sub_image_ = image_transport::create_subscription(
+        //     this, this->src_image_topic_name_, 
+        //     std::bind(&YoloXSrv::colorImageCallback, this, std::placeholders::_1), 
+        //     "raw");
+
+        // sleep 3sec
+        std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+        using namespace std::placeholders;
+        this->srv_detect_object_ = this->create_service<yolo_msgs::srv::DetectObject>("detect_object", std::bind(&YoloXSrv::colorImageSrvCallback, this, _1, _2, _3));
+
+        // this->pub_bboxes_ = this->create_publisher<yolo_msgs::msg::BoundingBoxes>(
+        //     this->publish_boundingbox_topic_name_,
+        //     10
+        // );
+        // this->pub_image_ = image_transport::create_publisher(this, this->publish_image_topic_name_);
+
+    }
+
+    void YoloXSrv::initializeParameter(){
+        this->declare_parameter<bool>("imshow_isshow", true);
+        this->declare_parameter<std::string>("model_path", "/root/ros2_ws/src/YOLOX-ROS/weights/tensorrt/YOLOX_outputs/nano/model_trt.engine");
+        this->declare_parameter<float>("conf", 0.3f);
+        this->declare_parameter<float>("nms", 0.45f);
+        this->declare_parameter<std::string>("device", "0");
+        this->declare_parameter<int>("image_size/width", 416);
+        this->declare_parameter<int>("image_size/height", 416);
+        this->declare_parameter<std::string>("model_type", "tensorrt");
+        this->declare_parameter<std::string>("src_image_topic_name", "image_raw");
+        this->declare_parameter<std::string>("publish_image_topic_name", "yolox/image_raw");        
+        this->declare_parameter<std::string>("publish_boundingbox_topic_name", "yolox/bounding_boxes");        
+
+        this->get_parameter("imshow_isshow", this->imshow_);
+        this->get_parameter("model_path", this->model_path_);
+        this->get_parameter("conf", this->conf_th_);
+        this->get_parameter("nms", this->nms_th_);
+        this->get_parameter("device", this->device_);
+        this->get_parameter("image_size/width", this->image_width_);
+        this->get_parameter("image_size/height", this->image_height_);
+        this->get_parameter("model_type", this->model_type_);
+        this->get_parameter("src_image_topic_name", this->src_image_topic_name_);
+        this->get_parameter("publish_image_topic_name", this->publish_image_topic_name_);
+        this->get_parameter("publish_boundingbox_topic_name", this->publish_boundingbox_topic_name_);
+
+        RCLCPP_INFO(this->get_logger(), "Set parameter imshow_isshow: %i", this->imshow_);
+        RCLCPP_INFO(this->get_logger(), "Set parameter model_path: '%s'", this->model_path_.c_str());
+        RCLCPP_INFO(this->get_logger(), "Set parameter conf: %f", this->conf_th_);
+        RCLCPP_INFO(this->get_logger(), "Set parameter nms: %f", this->nms_th_);
+        RCLCPP_INFO(this->get_logger(), "Set parameter device: %s", this->device_.c_str());
+        RCLCPP_INFO(this->get_logger(), "Set parameter image_size/width: %i", this->image_width_);
+        RCLCPP_INFO(this->get_logger(), "Set parameter image_size/height: %i", this->image_height_);
+        RCLCPP_INFO(this->get_logger(), "Set parameter model_type: '%s'", this->model_type_.c_str());
+        RCLCPP_INFO(this->get_logger(), "Set parameter src_image_topic_name: '%s'", this->src_image_topic_name_.c_str());
+        RCLCPP_INFO(this->get_logger(), "Set parameter publish_image_topic_name: '%s'", this->publish_image_topic_name_.c_str());
+
+    }
+    // void YoloXSrv::colorImageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& ptr){
+    //     auto img = cv_bridge::toCvCopy(ptr, "bgr8");
+    //     cv::Mat frame = img->image;
+
+    //     // fps
+    //     auto now = std::chrono::system_clock::now();
+    //     auto objects = this->yolox_->inference(frame);
+
+    //     yolox_cpp::utils::draw_objects(frame, objects);
+    //     if(this->imshow_){
+    //         cv::imshow(this->WINDOW_NAME_, frame);
+    //         auto key = cv::waitKey(1);
+    //         if(key == 27){
+    //             rclcpp::shutdown();
+    //         }
+    //     }
+
+    //     auto boxes = objects_to_bboxes(frame, objects, img->header);
+    //     this->pub_bboxes_->publish(boxes);
+
+    //     sensor_msgs::msg::Image::SharedPtr pub_img;
+    //     pub_img = cv_bridge::CvImage(img->header, "bgr8", frame).toImageMsg();
+    //     this->pub_image_.publish(pub_img);
+
+    //     auto end = std::chrono::system_clock::now();
+    //     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - now);
+    //     RCLCPP_INFO(this->get_logger(), "fps: %f", 1000.0f / elapsed.count());
+    // }
+
+    void YoloXSrv::colorImageSrvCallback(  const std::shared_ptr<rmw_request_id_t> request_header,
+                                            const std::shared_ptr<yolo_msgs::srv::DetectObject::Request> req,
+                                            std::shared_ptr<yolo_msgs::srv::DetectObject::Response> res
+                                )
+    {
+        RCLCPP_INFO(this->get_logger(), "colorImageSrvCallback");
+        int step = 0;
+
+        (void)request_header;
+
+        auto img = cv_bridge::toCvCopy(req->image, "bgr8");
+        cv::Mat frame = img->image;
+
+        RCLCPP_INFO(this->get_logger(), "step: %d", step++);
+
+        // fps
+        auto now = std::chrono::system_clock::now();
+        auto objects = this->yolox_->inference(frame);
+
+        RCLCPP_INFO(this->get_logger(), "step: %d", step++);
+
+        yolox_cpp::utils::draw_objects(frame, objects);
+        std::vector<yolo_msgs::msg::BoundingBox> boxes = objects_to_bboxes(frame, objects, img->header);
+        // std::vector<yolo_msgs::msg::BoundingBox> boxes;
+        res->bounding_boxes = boxes;
+
+        auto end = std::chrono::system_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - now);
+        RCLCPP_INFO(this->get_logger(), "fps: %f", 1000.0f / elapsed.count());
+    }
+
+    std::vector<yolo_msgs::msg::BoundingBox> YoloXSrv::objects_to_bboxes(cv::Mat frame, std::vector<yolox_cpp::Object> objects, std_msgs::msg::Header header){
+        std::vector<yolo_msgs::msg::BoundingBox> boxes;
+        // boxes.header = header;
+        for(auto obj: objects){
+            yolo_msgs::msg::BoundingBox box;
+            box.confidence = obj.prob;
+            box.class_id = yolox_cpp::COCO_CLASSES[obj.label];
+            box.xmin = obj.rect.x;
+            box.ymin = obj.rect.y;
+            box.xmax = (obj.rect.x + obj.rect.width);
+            box.ymax = (obj.rect.y + obj.rect.height);
+            // box.img_width = frame.cols;
+            // box.img_height = frame.rows;
+            // tracking id
+            // box.id = 0;
+            // depth
+            // box.center_dist = 0;
+            boxes.push_back(box);
+        }
+        return boxes;
+    }
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(yolox_ros_cpp_srv::YoloXSrv)
+


### PR DESCRIPTION
サービスに対応したYOLOX-ROSです。

バグ：Pub-Sub型は`auto objects = this->yolox_->inference(frame);`の呼び出し時にコンポーネントが落ちることがないのに、Service型は落ちてしまう。この時点では原因不明です…

bbox_ex_msgsに代わってyolo_msgsに変更。選択可能なようにしていく予定です。